### PR TITLE
Fix .t to handle Perl devel changes

### DIFF
--- a/t/001-autoformat.t
+++ b/t/001-autoformat.t
@@ -9,6 +9,7 @@ use POSIX qw( localeconv );
 # for testing known bug with locales that don't use '.' as a decimal
 # separator - see TODO file.
 # POSIX::setlocale( &POSIX::LC_ALL, 'sv_SE' );
+POSIX::setlocale( &POSIX::LC_ALL, 'C' );
 
 my $loc = localeconv;
 my $dec = $loc->{decimal_point};

--- a/t/autoform.t
+++ b/t/autoform.t
@@ -26,6 +26,7 @@ $Template::Test::PRESERVE = 1;
 # for testing known bug with locales that don't use '.' as a decimal
 # separator - see TODO file.
 # POSIX::setlocale( &POSIX::LC_ALL, 'sv_SE' );
+POSIX::setlocale( &POSIX::LC_ALL, 'C' );
 
 my $loc = localeconv;
 my $dec = $loc->{decimal_point};


### PR DESCRIPTION
Changes to core Perl during the v5.21 development series have broken
both test files in this module when run under a locale whose decimal
radix character is not a dot.  The solution is for the tests to just
make sure the locale is set to "C" before proceeding with the testing.

See https://rt.perl.org/Ticket/Display.html?id=123169

The changes to core Perl were necessary to get localeconv() to work
consistently.  Previously, it was somewhat haphazard whether it took
effect outside of 'use locale' or not.  Hence, just uncommenting the
lines for trying a Swedish locale in your files might not have worked
prior to the core Perl changes.