### PR TITLE
updating copyright year

### DIFF
--- a/lib/Template/Plugin/Autoformat.pm
+++ b/lib/Template/Plugin/Autoformat.pm
@@ -219,7 +219,7 @@ maintainer.
 
 =head1 COPYRIGHT
 
-Copyright (C) 2000-2007 Robert McArthur & Andy Wardley.  All Rights Reserved.
+Copyright (C) 2000-2015 Robert McArthur & Andy Wardley.  All Rights Reserved.
 
 This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.


### PR DESCRIPTION
Hi @karpet!

First of all, thanks for picking Template::Plugin::Autoformat up and giving it such a nice overhaul!

This tiny patch just bumps the copyright year up to 2015. Hope it helps :)

Cheers!