### PR TITLE
declaring minimum perl version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,4 +42,9 @@ if ( $ExtUtils::MakeMaker::VERSION ge '6.44' ) {
     };
 }
 
+if (  $ExtUtils::MakeMaker::VERSION ge '6.48' ) {
+    $opts{'MIN_PERL_VERSION'} = '5.6.0';
+}
+
+
 WriteMakefile(%opts);


### PR DESCRIPTION
Hi! Me again :)

Template::Plugin::Autoformat [passes **all** core Kwalitee metrics](http://cpants.cpanauthors.org/dist/Template-Plugin-Autoformat) which is pretty cool. In fact, the only extra metric missing is that it doesn't declare the minimum perl version to run. According to perlver, that version is 5.6.0:

    $ perlver .
    
       ----------------------------------------------------------------
     | file                              | explicit | syntax | external |
     | ---------------------------------------------------------------- |
     | Makefile.PL                       | ~        | v5.6.0 | n/a      |
     | lib/Template/Plugin/Autoformat.pm | ~        | v5.6.0 | n/a      |
     | t/001-autoformat.t                | ~        | v5.6.0 | n/a      |
     | t/autoform.t                      | ~        | v5.6.0 | n/a      |
     | ---------------------------------------------------------------- |
     | Minimum explicit version : ~                                     |
     | Minimum syntax version   : v5.6.0                                |
     | Minimum version of perl  : v5.6.0                                |
       ----------------------------------------------------------------

So I went ahead and added it to the Makefile.PL. Note that it [already has a PASS report on CPAN Testers for 5.6.2](http://www.cpantesters.org/cpan/report/afb81708-a556-11e4-8ded-4af7227a829d), so I think we're ok on 5.6. Hope it helps!

Cheers