### PR TITLE
100% coverage

### DIFF
--- a/lib/Template/Plugin/Autoformat.pm
+++ b/lib/Template/Plugin/Autoformat.pm
@@ -44,7 +44,7 @@ sub new {
             my $filtopt = ref $_[-1] eq 'HASH' ? pop : {};
             @$filtopt{ keys %$options } = values %$options;
             return sub {
-                tt_autoformat( @_, $filtopt );
+                _tt_autoformat( @_, $filtopt );
             };
         };
 
@@ -52,7 +52,7 @@ sub new {
         $plugin = sub {
             my $plugopt = ref $_[-1] eq 'HASH' ? pop : {};
             @$plugopt{ keys %$options } = values %$options;
-            tt_autoformat( @_, $plugopt );
+            _tt_autoformat( @_, $plugopt );
         };
     }
     else {
@@ -61,12 +61,12 @@ sub new {
             my $context = shift;
             my $filtopt = ref $_[-1] eq 'HASH' ? pop : {};
             return sub {
-                tt_autoformat( @_, $filtopt );
+                _tt_autoformat( @_, $filtopt );
             };
         };
 
         # plugin without options can be static
-        $plugin = \&tt_autoformat;
+        $plugin = \&_tt_autoformat;
     }
 
     # now define the filter and return the plugin
@@ -74,7 +74,7 @@ sub new {
     return $plugin;
 }
 
-sub tt_autoformat {
+sub _tt_autoformat {
     my $options = ref $_[-1] eq 'HASH' ? pop : {};
     my $form = $options->{form};
     my $out

--- a/t/001-autoformat.t
+++ b/t/001-autoformat.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use lib qw( ../lib );
 use Template qw( :status );
-use Test::More tests => 23;
+use Test::More tests => 25;
 use POSIX qw( localeconv );
 
 # for testing known bug with locales that don't use '.' as a decimal
@@ -21,6 +21,12 @@ my $opts = { POST_CHOMP => 1 };
 my ( $buf, $tmpl, $expected );
 
 ok( my $template = Template->new($opts), "Template->new" );
+
+###############################################################
+$tmpl = '[% USE Autoformat %][% "just some text" | Autoformat %]';
+$expected = "just some text\n\n";
+ok( $template->process( \$tmpl, {}, \$buf ), "process tmpl" );
+is( $buf, $expected, "got expected");
 
 ###############################################################
 $tmpl = <<EOF;
@@ -45,6 +51,7 @@ $expected = <<EOF;
 
 EOF
 
+$buf = "";
 ok( $template->process( \$tmpl, $vars, \$buf ), "process tmpl" );
 is( $buf, $expected, "got expected" );
 


### PR DESCRIPTION
Hi there! Me again :)

Template::Plugin::Autoformat is a nice short module with very thorough tests. In fact, when I ran Devel::Cover on it it accused 100% statement coverage and only a couple minor misses in coverage:

    ---------------------------- ------ ------ ------ ------ ------ ------ ------
    File                           stmt   bran   cond    sub    pod   time  total
    ---------------------------- ------ ------ ------ ------ ------ ------ ------
    ...late/Plugin/Autoformat.pm  100.0   91.6    n/a  100.0   50.0  100.0   96.6
    Total                         100.0   91.6    n/a  100.0   50.0  100.0   96.6
    ---------------------------- ------ ------ ------ ------ ------ ------ ------

There was only one branch call that was not being stressed by the tests, so I tracked it down and added it to the test suite. Finally, Devel::Cover complained that the `tt_autoformat()` function was not documented, and since it's really not documented *anywhere* and only used internally, I turned it into a "private" function by perl's coding standards (i.e. prefixed with an underscore).

Now Template::Plugin::Autoformat has 100% test coverage - which is pretty rare, actually!

    ---------------------------- ------ ------ ------ ------ ------ ------ ------
    File                           stmt   bran   cond    sub    pod   time  total
    ---------------------------- ------ ------ ------ ------ ------ ------ ------
    ...late/Plugin/Autoformat.pm  100.0  100.0    n/a  100.0  100.0  100.0  100.0
    Total                         100.0  100.0    n/a  100.0  100.0  100.0  100.0
    ---------------------------- ------ ------ ------ ------ ------ ------ ------

Again, hope it helps!

Cheers