### PR TITLE
prevent "NAME must be a package name" warning

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 my %opts = (
-    'NAME'         => 'Template-Plugin-Autoformat',
+    'NAME'         => 'Template::Plugin::Autoformat',
     'VERSION_FROM' => 'lib/Template/Plugin/Autoformat.pm',
     'PMLIBDIRS'    => ['lib'],
     'PREREQ_PM'    => {


### PR DESCRIPTION
Hi! This is the last one - promise! :)

While I was working on the previous pull requests, I noticed every time I ran `perl Makefile.PL` I got this message on the terminal:

    Warning: NAME must be a package name

As it turns out, the NAME field must contain the main package's name (*Template::Plugin::Autoformat*) not the dist name (*Template-Plugin-Autoformat*). This patch makes that annoying message (and any potential collateral issues it may be causing) go away.